### PR TITLE
Add support for non-scalar indexing

### DIFF
--- a/src/tformedarrays.jl
+++ b/src/tformedarrays.jl
@@ -33,17 +33,17 @@ end
 
 Base.size(A::TransformedArray) = size(A.data)
 
-function Base.getindex{T}(A::TransformedArray{T,2}, i, j)
+function Base.getindex{T}(A::TransformedArray{T,2}, i::Number, j::Number)
     x, y = tformfwd(A.tform, i, j)
     A.data[x, y]
 end
 
-function Base.getindex{T}(A::TransformedArray{T,3}, i, j, k)
+function Base.getindex{T}(A::TransformedArray{T,3}, i::Number, j::Number, k::Number)
     x, y, z = tformfwd(A.tform, i, j, k)
     A.data[x, y, z]
 end
 
-Base.similar(A::TransformedArray, T=eltype(A), dims=size(A)) = Array(T, dims)
+Base.similar{T}(A::TransformedArray, ::Type{T}, dims::Dims) = Array(T, dims)
 
 """
 `transform(A, tfm; origin_dest=center(A), origin_src=center(A)`

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -192,7 +192,7 @@ rotation2(angle) = [cos(angle) -sin(angle); sin(angle) cos(angle)]
 
 function tformrotate(angle)
     A = rotation2(angle)
-    AffineTransform(A, zeros(eltype(A),2))
+    AffineTransform{eltype(A), 2}(A, zeros(eltype(A),2))
 end
 
 # The following assumes uaxis is normalized


### PR DESCRIPTION
With these minor adjustments, I'm able to write my rotate-and-crop function that I proposed in timholy/Images.jl#397 as:

```jl
function rotate_and_crop{T}(A::AbstractMatrix{T}, θ, region=(1:size(A, 1), 1:size(A, 2)), fill=zero(T))
    etp = extrapolate(interpolate(A, BSpline(Linear()), OnGrid()), fill)
    R = TransformedArray(etp, tformrotate(θ))
    Base.unsafe_getindex(R, region[1], region[2])
end
# While the above will work for images, it may iterate through them inefficiently depending on the storage order
rotate_and_crop(A::Image, θ, region) = shareproperties(A, rotate_and_crop(A.data, θ, region))
```

Amazingly, your much more general, higher level framework has performance on par with my specialized rotate function. Very nice work here!