### PR TITLE
Fix for non-real numbers

### DIFF
--- a/src/tformedarrays.jl
+++ b/src/tformedarrays.jl
@@ -143,11 +143,11 @@ center(A::AbstractArray) = [(size(A,d)+1)/2 for d = 1:ndims(A)]
 function irange(imin::Int, imax::Int, coef, offset, upper)
     const thresh = 10^4/typemax(Int)  # needed to avoid InexactError for results with abs() bigger than typemax
     if coef > thresh
-        return max(imin, floor(Int, (1-offset)/coef)), min(imax, ceil(Int, (upper-offset)/coef))
+        return max(imin, floor(Int, real((1-offset)/coef))), min(imax, ceil(Int, real((upper-offset)/coef)))
     elseif coef < -thresh
-        return max(imin, floor(Int, (upper-offset)/coef)), min(imax, ceil(Int, (1-offset)/coef))
+        return max(imin, floor(Int, real((upper-offset)/coef))), min(imax, ceil(Int, real((1-offset)/coef)))
     else
-        if 1 <= offset <= upper
+        if 1 <= real(offset) <= upper
             return imin, imax
         else
             return 1, 0   # empty range

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 Images
+DualNumbers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,3 +222,10 @@ dest3 = zeros(3,3)
 itp = interpolate(A, BSpline(Constant()), OnCell())
 tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
 @test AffineTransforms.transform!(dest, tA) == [2 3; 6 7]
+
+# Transforms with non-real numbers
+using DualNumbers
+a = AffineTransforms.tformtranslate([0,dual(1,0)])
+A = reshape(1:9, 3, 3)
+At = AffineTransforms.transform(A, a)
+@test real(At[:,1:2]) == A[:,2:3]


### PR DESCRIPTION
When performing optimizations, it's quite possible that the transform parameters will be GradientNumbers or DualNumbers.