### PR TITLE
Case where the matrix and the translation do not have the same eltype.

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 Images 0.6.0
 DualNumbers
+Unitful

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -221,3 +221,9 @@ end
     At = AffineTransforms.transform(A, a)
     @test At[:,1:2] == A[:,2:3]
 end
+
+@testset "With separates types for linear transform and translation" begin
+	using Unitful: @u_str
+    aff = AffineTransforms.AffineTransform(Val{:units}, [0 -1; 1 0], [2, 3]u"nm")
+    @test aff * ([1, 2]u"nm") == [0, 4]u"nm"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 import AffineTransforms
 
 # Pure translations
-for nd = 1:4
+@testset "Pure $(nd)D translations" for nd = 1:4
     t1 = rand(nd)
     t2 = rand(nd)
     ident = eye(nd)
@@ -36,54 +36,56 @@ for nd = 1:4
     end
 end
 
-# Pure rotations
-@test_approx_eq AffineTransforms.tformrotate(0).scalefwd eye(2)
-@test_approx_eq AffineTransforms.tformrotate(pi/2)*[1,0] [0,1]
-@test_approx_eq AffineTransforms.tformrotate(pi/2).scalefwd [0 -1; 1 0]
-@test_approx_eq AffineTransforms.tformrotate(pi)*[1,0] [-1,0]
-@test_approx_eq AffineTransforms.tformrotate(3pi/2)*[1,0] [0,-1]
-@test_approx_eq AffineTransforms.tformrotate([1,0,0],pi/2).scalefwd [1 0 0; 0 0 -1; 0 1 0]
-@test_approx_eq AffineTransforms.tformrotate([1,0,0],pi/2)*[1,0,0] [1,0,0]
-@test_approx_eq AffineTransforms.tformrotate([0,1,0],pi/2)*[1,0,0] [0,0,-1]
-@test_approx_eq AffineTransforms.tformrotate([0,0,1],pi/2)*[1,0,0] [0,1,0]
-s2 = 1/sqrt(2)
-@test_approx_eq AffineTransforms.tformrotate([0,1,0],pi/4).scalefwd [s2 0 s2; 0 1 0; -s2 0 s2]
-@test_approx_eq AffineTransforms.tformrotate([0,0,1],pi/4).scalefwd [s2 -s2 0; s2 s2 0; 0 0 1]
+@testset "Pure rotations" begin
+    @test_approx_eq AffineTransforms.tformrotate(0).scalefwd eye(2)
+    @test_approx_eq AffineTransforms.tformrotate(pi/2)*[1,0] [0,1]
+    @test_approx_eq AffineTransforms.tformrotate(pi/2).scalefwd [0 -1; 1 0]
+    @test_approx_eq AffineTransforms.tformrotate(pi)*[1,0] [-1,0]
+    @test_approx_eq AffineTransforms.tformrotate(3pi/2)*[1,0] [0,-1]
+    @test_approx_eq AffineTransforms.tformrotate([1,0,0],pi/2).scalefwd [1 0 0; 0 0 -1; 0 1 0]
+    @test_approx_eq AffineTransforms.tformrotate([1,0,0],pi/2)*[1,0,0] [1,0,0]
+    @test_approx_eq AffineTransforms.tformrotate([0,1,0],pi/2)*[1,0,0] [0,0,-1]
+    @test_approx_eq AffineTransforms.tformrotate([0,0,1],pi/2)*[1,0,0] [0,1,0]
+    s2 = 1/sqrt(2)
+    @test_approx_eq AffineTransforms.tformrotate([0,1,0],pi/4).scalefwd [s2 0 s2; 0 1 0; -s2 0 s2]
+    @test_approx_eq AffineTransforms.tformrotate([0,0,1],pi/4).scalefwd [s2 -s2 0; s2 s2 0; 0 0 1]
 
-theta1 = pi/2
-# 2d
-tfm1 = AffineTransforms.tformrotate(theta1)
-tfm2 = AffineTransforms.tformrotate(theta1)
-x = rand(2)
-@test_approx_eq tfm1*(tfm2*x) -x
-@test_approx_eq (tfm1*tfm2)*x -x
-@test_approx_eq tfm1\(tfm2*x)  x
-@test_approx_eq (tfm1\tfm2)*x  x
-@test_approx_eq (tfm1*tfm1*tfm1*tfm1)*x  x
-r = AffineTransforms.tformfwd(tfm1, x...)
-@test [r...] == tfm1*x
-r = AffineTransforms.tforminv(tfm1, x...)
-@test [r...] == tfm1\x
+    theta1 = pi/2
+    @testset "> 2d" begin
+        tfm1 = AffineTransforms.tformrotate(theta1)
+        tfm2 = AffineTransforms.tformrotate(theta1)
+        x = rand(2)
+        @test_approx_eq tfm1*(tfm2*x) -x
+        @test_approx_eq (tfm1*tfm2)*x -x
+        @test_approx_eq tfm1\(tfm2*x)  x
+        @test_approx_eq (tfm1\tfm2)*x  x
+        @test_approx_eq (tfm1*tfm1*tfm1*tfm1)*x  x
+        r = AffineTransforms.tformfwd(tfm1, x...)
+        @test [r...] == tfm1*x
+        r = AffineTransforms.tforminv(tfm1, x...)
+        @test [r...] == tfm1\x
+    end
 
-# 3d
-uaxis = rand(3); uaxis = uaxis/norm(uaxis)
-tfm1 = AffineTransforms.tformrotate(uaxis*theta1)
-tfm2 = AffineTransforms.tformrotate(uaxis*theta1)
-x = rand(3)
-xparallel = dot(x,uaxis)*uaxis
-xperp = x - xparallel
-@test_approx_eq tfm1*(tfm2*x) xparallel-xperp
-@test_approx_eq (tfm1*tfm2)*x xparallel-xperp
-@test_approx_eq tfm1\(tfm2*x)  x
-@test_approx_eq (tfm1\tfm2)*x  x
-@test_approx_eq (tfm1*tfm1*tfm1*tfm1)*x  x
-r = AffineTransforms.tformfwd(tfm1, x...)
-@test [r...] == tfm1*x
-r = AffineTransforms.tforminv(tfm1, x...)
-@test [r...] == tfm1\x
+    @testset "> 3d" begin
+        uaxis = rand(3); uaxis = uaxis/norm(uaxis)
+        tfm1 = AffineTransforms.tformrotate(uaxis*theta1)
+        tfm2 = AffineTransforms.tformrotate(uaxis*theta1)
+        x = rand(3)
+        xparallel = dot(x,uaxis)*uaxis
+        xperp = x - xparallel
+        @test_approx_eq tfm1*(tfm2*x) xparallel-xperp
+        @test_approx_eq (tfm1*tfm2)*x xparallel-xperp
+        @test_approx_eq tfm1\(tfm2*x)  x
+        @test_approx_eq (tfm1\tfm2)*x  x
+        @test_approx_eq (tfm1*tfm1*tfm1*tfm1)*x  x
+        r = AffineTransforms.tformfwd(tfm1, x...)
+        @test [r...] == tfm1*x
+        r = AffineTransforms.tforminv(tfm1, x...)
+        @test [r...] == tfm1\x
+    end
+end
 
-# random transformations
-for nd = 1:4
+@testset "Random $(nd)D transformations" for nd = 1:4
     A = eye(nd) + 0.1*randn(nd,nd)
     b = randn(nd)
     tfm = AffineTransforms.AffineTransform(A, b)
@@ -104,118 +106,118 @@ for nd = 1:4
     end
 end
 
-# Pure rotations in 2d and 3d
-for i = 1:20
-    th = pi*(rand()-0.5)
-    R = AffineTransforms.rotation2(th)
-    @test_approx_eq th AffineTransforms.rotationparameters(R)
-end
-for i = 1:100
-    ax = randn(3)
-    n = norm(ax)
-    if n == 0
-        continue
+@testset "Pure rotations in 2d and 3d" begin
+    for i = 1:20
+        th = pi*(rand()-0.5)
+        R = AffineTransforms.rotation2(th)
+        @test_approx_eq th AffineTransforms.rotationparameters(R)
     end
-    ax = ax / n
-    th = pi*rand()
-    rv = th*ax
-    R = AffineTransforms.rotation3(rv)
-    @test_approx_eq rv AffineTransforms.rotationparameters(R)
-end
-
-# Transformation of arrays
-using Interpolations, Images # Images for padarray
-import AffineTransforms: center
-
-padwith0(A) = parent(padarray(A, Fill(0, (2,2))))  # take parent for "old style" indexing
-
-for (IT,GT) in ((BSpline(Constant()), OnCell()),
-                (BSpline(Linear()), OnGrid()),
-                (BSpline(Quadratic(Flat())), OnCell()))
-    A = padwith0([1 1; 1 2])
-    itp = interpolate(A, IT, GT)
-    tfm = AffineTransforms.tformtranslate([1,0])
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 2; 0 0]
-    @test_approx_eq tA[3,3] 1
-    @test_approx_eq tA[3,4] 2
-    tfm = AffineTransforms.tformtranslate([0,1])
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 0; 2 0]
-    tfm = AffineTransforms.tformtranslate([-1,0])
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [0 0; 1 1]
-    tfm = AffineTransforms.tformtranslate([0,-1])
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [0 1; 0 1]
-
-    A = padwith0([2 1; 1 1])
-    itp = interpolate(A, IT, GT)
-    tfm = AffineTransforms.tformrotate(pi/2)
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 2; 1 1]
-    tfm = AffineTransforms.tformrotate(-pi/2)
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 1; 2 1]
-
-    # Check that getindex and transform yield the same results
-    A = rand(6,6)
-    itp = interpolate(A, IT, GT)
-    tfm = AffineTransforms.tformrotate(pi/7)*AffineTransforms.tformtranslate(rand(2))
-    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-    dest = AffineTransforms.transform(tA)
-    tfm_recentered = AffineTransforms.AffineTransform(tfm.scalefwd, tfm.offset + center(A) - tfm.scalefwd*center(dest))
-    tA_recentered = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm_recentered)
-    nbad = 0
-    for j = 1:size(dest,2), i = 1:size(dest,1)
-        val = tA_recentered[i,j]
-        # try
-        #     @test isfinite(dest[i,j]) == isfinite(val)
-        # catch err
-        #     @show dest tA_recentered
-        #     rethrow(err)
-        # end
-        nbad += isfinite(dest[i,j]) != isfinite(val)
-        if isfinite(val) && isfinite(dest[i,j])
-            @test abs(val-dest[i,j]) < 1e-12
+    for i = 1:100
+        ax = randn(3)
+        n = norm(ax)
+        if n == 0
+            continue
         end
+        ax = ax / n
+        th = pi*rand()
+        rv = th*ax
+        R = AffineTransforms.rotation3(rv)
+        @test_approx_eq rv AffineTransforms.rotationparameters(R)
     end
-    @test nbad < 3
-    dest = AffineTransforms.transform(tA, origin_src=zeros(2), origin_dest=zeros(2))
-    nbad = 0
-    for j = 1:size(dest,2), i = 1:size(dest,1)
-        val = tA[i,j]
-        # try
-        #     @test isfinite(dest[i,j]) == isfinite(val)
-        # catch err
-        #     @show dest tA
-        #     rethrow(err)
-        # end
-        nbad += isfinite(dest[i,j]) != isfinite(val)
-        if isfinite(val) && isfinite(dest[i,j])
-            @test abs(val-dest[i,j]) < 1e-12
-        end
-    end
-    @test nbad < 3
 end
 
-A = Float64[1 2 3 4; 5 6 7 8]
-tfm = AffineTransforms.tformeye(2)
-dest = zeros(2,2)
+@testset "Transformation of arrays" begin
+    using Interpolations, Images # Images for padarray
+    import AffineTransforms: center
 
-itp = interpolate(A, BSpline(Linear()), OnGrid())
-tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-@test_approx_eq AffineTransforms.transform!(dest, tA) [2 3; 6 7]
-dest3 = zeros(3,3)
-@test_approx_eq AffineTransforms.transform!(dest3, tA) [NaN NaN NaN; 3.5 4.5 5.5; NaN NaN NaN]
+    padwith0(A) = parent(padarray(A, [2,2], [2,2], "value", 0))
 
-itp = interpolate(A, BSpline(Constant()), OnCell())
-tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
-@test AffineTransforms.transform!(dest, tA) == [2 3; 6 7]
+    for (IT,GT) in ((BSpline(Constant()), OnCell()),
+                    (BSpline(Linear()), OnGrid()),
+                    (BSpline(Quadratic(Flat())), OnCell()))
+        A = padwith0([1 1; 1 2])
+        itp = interpolate(A, IT, GT)
+        tfm = AffineTransforms.tformtranslate([1,0])
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 2; 0 0]
+        @test_approx_eq tA[3,3] 1
+        @test_approx_eq tA[3,4] 2
+        tfm = AffineTransforms.tformtranslate([0,1])
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 0; 2 0]
+        tfm = AffineTransforms.tformtranslate([-1,0])
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [0 0; 1 1]
+        tfm = AffineTransforms.tformtranslate([0,-1])
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [0 1; 0 1]
 
-# Transforms with non-real numbers
-using DualNumbers
-a = AffineTransforms.tformtranslate([0,dual(1,0)])
-A = reshape(1:9, 3, 3)
-At = AffineTransforms.transform(A, a)
-@test At[:,1:2] == A[:,2:3]
+        A = padwith0([2 1; 1 1])
+        itp = interpolate(A, IT, GT)
+        tfm = AffineTransforms.tformrotate(pi/2)
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 2; 1 1]
+        tfm = AffineTransforms.tformrotate(-pi/2)
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        @test_approx_eq AffineTransforms.transform(tA)[3:4,3:4] [1 1; 2 1]
+
+        # Check that getindex and transform yield the same results
+        A = rand(6,6)
+        itp = interpolate(A, IT, GT)
+        tfm = AffineTransforms.tformrotate(pi/7)*AffineTransforms.tformtranslate(rand(2))
+        tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+        dest = AffineTransforms.transform(tA)
+        tfm_recentered = AffineTransforms.AffineTransform(tfm.scalefwd, tfm.offset + center(A) - tfm.scalefwd*center(dest))
+        tA_recentered = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm_recentered)
+        nbad = 0
+        for j = 1:size(dest,2), i = 1:size(dest,1)
+            val = tA_recentered[i,j]
+            # try
+            #     @test isfinite(dest[i,j]) == isfinite(val)
+            # catch err
+            #     @show dest tA_recentered
+            #     rethrow(err)
+            # end
+            nbad += isfinite(dest[i,j]) != isfinite(val)
+            if isfinite(val) && isfinite(dest[i,j])
+                @test abs(val-dest[i,j]) < 1e-12
+            end
+        end
+        @test nbad < 3
+        dest = AffineTransforms.transform(tA, origin_src=zeros(2), origin_dest=zeros(2))
+        nbad = 0
+        for j = 1:size(dest,2), i = 1:size(dest,1)
+            val = tA[i,j]
+            # try
+            #     @test isfinite(dest[i,j]) == isfinite(val)
+            # catch err
+            #     @show dest tA
+            #     rethrow(err)
+            # end
+            nbad += isfinite(dest[i,j]) != isfinite(val)
+            if isfinite(val) && isfinite(dest[i,j])
+                @test abs(val-dest[i,j]) < 1e-12
+            end
+        end
+        @test nbad < 3
+    end
+
+    padwith0(A) = parent(padarray(A, Fill(0, (2,2))))  # take parent for "old style" indexing
+
+    itp = interpolate(A, BSpline(Linear()), OnGrid())
+    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+    @test_approx_eq AffineTransforms.transform!(dest, tA) [2 3; 6 7]
+    dest3 = zeros(3,3)
+    @test_approx_eq AffineTransforms.transform!(dest3, tA) [NaN NaN NaN; 3.5 4.5 5.5; NaN NaN NaN]
+
+    itp = interpolate(A, BSpline(Constant()), OnCell())
+    tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)
+    @test AffineTransforms.transform!(dest, tA) == [2 3; 6 7]
+
+    # Transforms with non-real numbers
+    using DualNumbers
+    a = AffineTransforms.tformtranslate([0,dual(1,0)])
+    A = reshape(1:9, 3, 3)
+    At = AffineTransforms.transform(A, a)
+    @test At[:,1:2] == A[:,2:3]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,7 +130,7 @@ end
     using Interpolations, Images # Images for padarray
     import AffineTransforms: center
 
-    padwith0(A) = parent(padarray(A, [2,2], [2,2], "value", 0))
+    padwith0(A) = parent(padarray(A, Fill(0, (2,2))))
 
     for (IT,GT) in ((BSpline(Constant()), OnCell()),
                     (BSpline(Linear()), OnGrid()),
@@ -202,7 +202,9 @@ end
         @test nbad < 3
     end
 
-    padwith0(A) = parent(padarray(A, Fill(0, (2,2))))  # take parent for "old style" indexing
+    A = Float64[1 2 3 4; 5 6 7 8]
+    tfm = AffineTransforms.tformeye(2)
+    dest = zeros(2,2)
 
     itp = interpolate(A, BSpline(Linear()), OnGrid())
     tA = AffineTransforms.TransformedArray(extrapolate(itp, NaN), tfm)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,8 +224,8 @@ end
     @test At[:,1:2] == A[:,2:3]
 end
 
+using Unitful: @u_str
 @testset "With separates types for linear transform and translation" begin
-	using Unitful: @u_str
-    aff = AffineTransforms.AffineTransform(Val{:units}, [0 -1; 1 0], [2, 3]u"nm")
+    aff = AffineTransforms.AffineTransform([0 -1; 1 0], [2, 3]u"nm")
     @test aff * ([1, 2]u"nm") == [0, 4]u"nm"
 end


### PR DESCRIPTION
The main case of interest are vectorial spaces with units, say via Unitful. Then the translations in the affine transforms also have units, but the matrices are unitless.

This pull-request "works", as evidenced by a test. But the API is probably not satisfactory. Any recommendations/ideas on how to go about this?